### PR TITLE
Composable Error Types without Monad Transformers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,9 @@ before_install:
 # Install LLVM 8.0
 - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" | sudo tee -a /etc/apt/sources.list
-- sudo apt-get update -qq
-- sudo apt-get install llvm-8-dev llvm-8-tools -y
+- sudo apt clean
+- sudo apt update
+- sudo apt install -y llvm-8-dev llvm-8-tools
 ## Install CUDA 10 toolkit -> No CUDA device available, so accelerate wont run.
 #- INSTALLER=cuda-repo-${UBUNTU_VERSION}_${CUDA}_amd64.deb
 #- wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${INSTALLER}

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
 # Install LLVM 8.0
 - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" | sudo tee -a /etc/apt/sources.list
+- sudo rm -rf /var/lib/apt/lists/*
 - sudo apt clean
 - sudo apt update
 - sudo apt install -y llvm-8-dev llvm-8-tools

--- a/app/testing.hs
+++ b/app/testing.hs
@@ -102,7 +102,7 @@ testVCross =
       vecB = S.fromList [0, 1, 0]  :: Seq Double
       vecC = S.fromList [-1, 0, 0] :: Seq Double
   in  testCase "Vectors Cross Product" $
-        vCross vecA vecB @?= Right vecC
+        (vCross vecA vecB :: Maybe (Seq Double)) @?= Just vecC
 
 
 {-

--- a/app/testing.hs
+++ b/app/testing.hs
@@ -24,6 +24,7 @@ import           System.FilePath            hiding ((<.>))
 import           Test.Tasty
 import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
+--import Control.Exception.Safe
 
 
 main :: IO ()
@@ -323,7 +324,7 @@ data MolWriterEnv = MolWriterEnv
                                                     --   'Molecule' after parsing 'writerFile'
                                                     --   again.
   , mweParser     :: Parser Molecule                -- ^ A 'Parser' for the 'Molecule'.
-  , mweWriter     :: Molecule -> Either String Text -- ^ A writer for 'Molecule'
+  , mweWriter     :: Molecule -> Either SomeException Text -- ^ A writer for 'Molecule'
   }
 
 {-|
@@ -332,23 +333,28 @@ writer format, and the writer representation as JSON again. Compares the writer 
 against the original JSON representation.
 -}
 mweParseWriteParseWrite :: ReaderT MolWriterEnv IO ()
-mweParseWriteParseWrite molWriterEnv = do
-    -- Get the environment.
-    env               <- ask
-    -- Read and parse the original (external) file
-    origMol           <- liftIO $ T.readFile (mweOrigFile env)
-
-    -- Get the writer representation of the original molecule.
-    origMolFormatText <- mweWriteFileFormat origMol
-    -- Write internal representation and writer representation of the original molecule.
-    liftIO . T.writeFile (mweGoldenJSON env) . writeSpicy $ origMol
-    liftIO . T.writeFile (mweWriterFile env) $ origMolFormatText
-    -- Parse the writer representation again.
-    writerMol         <- mweProcessFile WriterFile
-    -- Write the internal representation of the parsed writer representation.
-    liftIO $ T.writeFile (mweWriterJSON env) . writeSpicy $ writerMol
-    return writerMol
-  return ()
+mweParseWriteParseWrite = do
+  -- Get the environment.
+  env      <- ask
+  -- Read and parse the original (external) file
+  origRaw  <- liftIO $ T.readFile (mweOrigFile env)
+  -- Parse the original file.
+  origMol  <- parse' (mweParser env) origRaw
+  -- Get the text representation of the original file.
+  let origText = (mweWriter env) origMol
+  -- Write the Spicy JSON representation of the original molecule (Golden File) and the writer (to
+  -- test) representation of the original molecule.
+  liftIO . T.writeFile (mweGoldenJSON env) . writeSpicy $ origMol
+  case origText of
+    Left e  -> liftIO . T.writeFile (mweWriterFile env) . T.pack . show $ e
+    Right t -> liftIO . T.writeFile (mweWriterFile env) $ t
+  -- Parse the writer result again with the supplied parser.
+  writerRaw <- liftIO $ T.readFile (mweWriterFile env)
+  -- Parse the result from the writer.
+  writerMol <- parse' (mweParser env) writerRaw
+  -- Get the text representation of the writer molecule and write to the Spicy JSON representation
+  -- (Output file).
+  liftIO . T.writeFile (mweWriterJSON env) . writeSpicy $ writerMol
 
 {-|
 This function provides a wrapper around 'goldenVsFile', tuned for the writer tests.
@@ -359,7 +365,7 @@ mweGoldenVsFile env =
     (mweTestName env)
     (mweGoldenJSON env)
     (mweWriterJSON env)
-    (mweParseWriteParseWrite env)
+    (runReaderT mweParseWriteParseWrite env)
 
 testWriterMolecule :: TestTree
 testWriterMolecule = testGroup "Molecule Formats"

--- a/app/testing.hs
+++ b/app/testing.hs
@@ -3,6 +3,7 @@ Unit testing and golden testing (unit testing based on files) for Spicy. Test al
 parts of Spicy. This is especially Spicy.MolecularSystem and Spicy.Parser.
 All tests are required to pass. There is no gray zone!!
 -}
+import           Control.Exception.Safe
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Except
@@ -326,47 +327,17 @@ data MolWriterEnv = MolWriterEnv
   }
 
 {-|
-Defines a job step for the test case. Either process the original input file (step 1), or the
-spicy-written file.
--}
-data MolWriterStep = OrigFile | WriterFile deriving Eq
-
-{-|
-Process input files of the test type (XYZ, TXYZ, MOL2, PDB, ...) and parse them to an 'Either'
-'String' 'Molecule'.
--}
-mweProcessFile :: MolWriterStep -> ExceptT String (ReaderT MolWriterEnv IO) Molecule
-mweProcessFile step = ExceptT $ do
-  env <- ask
-  let inputToRead =
-        case step of
-          OrigFile   -> mweOrigFile env
-          WriterFile -> mweWriterFile env
-  raw <- liftIO $ T.readFile inputToRead
-  return $ eitherResult . parse (mweParser env) $ raw
-
-{-|
-Process a given 'Molecule' with a monad transformer to a 'Either' 'String' 'Text', where 'Text' is
-representing the molecule in the file format representation to be tested.
--}
-mweWriteFileFormat :: Molecule -> ExceptT String (ReaderT MolWriterEnv IO) Text
-mweWriteFileFormat mol = ExceptT $ do
-  env <- ask
-  let molFormatText = (mweWriter env) $ mol
-  return molFormatText
-
-{-|
 Provides the IO action for 'goldenVsFile', writing the original representation in JSON and the
 writer format, and the writer representation as JSON again. Compares the writer JSON representation
 against the original JSON representation.
 -}
-mweParseWriteParseWrite :: MolWriterEnv -> IO ()
+mweParseWriteParseWrite :: ReaderT MolWriterEnv IO ()
 mweParseWriteParseWrite molWriterEnv = do
-  _ <- flip runReaderT molWriterEnv . runExceptT $ do
     -- Get the environment.
-    env               <- lift ask
+    env               <- ask
     -- Read and parse the original (external) file
-    origMol           <- mweProcessFile OrigFile
+    origMol           <- liftIO $ T.readFile (mweOrigFile env)
+
     -- Get the writer representation of the original molecule.
     origMolFormatText <- mweWriteFileFormat origMol
     -- Write internal representation and writer representation of the original molecule.

--- a/app/testing.hs
+++ b/app/testing.hs
@@ -5,8 +5,6 @@ All tests are required to pass. There is no gray zone!!
 -}
 import           Control.Exception.Safe
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Reader
 import           Data.Aeson
 import           Data.Attoparsec.Text.Lazy
@@ -24,7 +22,6 @@ import           System.FilePath            hiding ((<.>))
 import           Test.Tasty
 import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
---import Control.Exception.Safe
 
 
 main :: IO ()
@@ -130,26 +127,16 @@ data ParserEnv = ParserEnv
 {-|
 This provided the IO action for 'goldenVsFile' for testing of the parsers.
 -}
-peParseAndWrite :: ParserEnv -> IO ()
-peParseAndWrite parserEnv = do
-  _ <- flip runReaderT parserEnv . runExceptT $ do
-    -- Get the environment informations.
-    env <- lift ask
-    -- Parse the input file.
-    mol <- peProcessFile
-    -- Write the internal representation of the parser result to JSON file.
-    liftIO . T.writeFile (peOutputFile env) . writeSpicy $ mol
-    return mol
-  return ()
-
-{-|
-Reads and parses a test file for the parser tests.
--}
-peProcessFile :: ExceptT String (ReaderT ParserEnv IO) Molecule
-peProcessFile = ExceptT $ do
+peParseAndWrite :: ReaderT ParserEnv IO ()
+peParseAndWrite = do
+  -- Get the environment informations.
   env <- ask
+  -- Read the input file.
   raw <- liftIO $ T.readFile (peInputFile env)
-  return $ eitherResult . parse (peParser env) $ raw
+  -- Parse the input file.
+  mol <- parse' (peParser env) raw
+  -- Write the internal representation of the parser result to JSON file.
+  liftIO . T.writeFile (peOutputFile env) . writeSpicy $ mol
 
 {-|
 Wrapper for 'goldenVsFile' for the 'Spicy.Parser' test cases.
@@ -160,7 +147,7 @@ peGoldenVsFile env =
     (peTestName env)
     (peGoldenFile env)
     (peOutputFile env)
-    (peParseAndWrite env)
+    (runReaderT peParseAndWrite env)
 
 testParser :: TestTree
 testParser = testGroup "Parser"
@@ -430,280 +417,3 @@ testWriterPDB1 =
         , mweWriter     = writePDB
         }
   in mweGoldenVsFile testEnv
-
-
-----------------------------------------------------------------------------------------------------
--- Test cases for MolecularSystem
-{-
-testMolecularSystem :: TestTree
-testMolecularSystem = testGroup "Molecular System"
-  [ testGuessBonds1
-  , testGuessBonds2
-  , testGuessBonds3
-  , testGuessBonds4
-  , testGuessBonds5
-  , testGuessBonds6
-  , testIsolateLayer1
-  , testIsolateLayer2
-  , testFragmentDetection1
-  , testFragmentDetection2
-  , testFragmentDetection3
-  , testWrapFragmentsToBox1
-  , testReplicateSystemAlongAxis1
-  , testReplicateSystemAlongAxis2
-  , testReplicateSystemAlongAxis3
-  , testFindNearestAtom1
-  , testFilterByCriteria1
-  , testFilterByCriteria2
-  , testFilterByCriteria3
-  ]
-
--- Guessing of bonds by colvant radii
-testGuessBonds1 :: TestTree
-testGuessBonds1 = goldenVsString
-  "Guess bonds - defaults (N2 in binding distance)"
-  "goldentests/output/N2_bonded__GuessBonds1.txyz" $ do
-    raw <- T.readFile "goldentests/input/N2_bonded.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let molResult = guessBonds Nothing molInput
-        return . LBS.fromString . writeTXYZ $ molResult
-
-testGuessBonds2 :: TestTree
-testGuessBonds2 = goldenVsString
-  "Guess bonds - defaults (N2 in non-binding distance)"
-  "goldentests/output/N2_nonbonded__GuessBonds2.txyz" $ do
-    raw <- T.readFile "goldentests/input/N2_nonbonded.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let molResult = guessBonds Nothing molInput
-        return . LBS.fromString . writeTXYZ $ molResult
-
-testGuessBonds3 :: TestTree
-testGuessBonds3 = goldenVsString
-  "Guess bonds - custom cutoff (N2 in binding distance)"
-  "goldentests/output/N2_bonded__GuessBonds3.txyz" $ do
-    raw <- T.readFile "goldentests/input/N2_bonded.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let molResult = guessBonds (Just 0.1) molInput
-        return . LBS.fromString . writeTXYZ $ molResult
-
-testGuessBonds4 :: TestTree
-testGuessBonds4 = goldenVsString
-  "Guess bonds - custom cutoff (N2 in non-binding distance)"
-  "goldentests/output/N2_nonbonded__GuessBonds4.txyz" $ do
-    raw <- T.readFile "goldentests/input/N2_nonbonded.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let molResult = guessBonds (Just 7.042254) molInput
-        return . LBS.fromString . writeTXYZ $ molResult
-
-testGuessBonds5 :: TestTree
-testGuessBonds5 = goldenVsString
-  "Guess bonds - 1.2 x R_covalent (Heme like system)"
-  "goldentests/output/FePorphyrine__GuessBonds5.txyz" $ do
-    raw <- T.readFile "goldentests/input/FePorphyrine.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let molResult = guessBonds (Just 1.2) molInput
-        return . LBS.fromString . writeTXYZ $ molResult
-
-testGuessBonds6 :: TestTree
-testGuessBonds6 = goldenVsString
-  "Guess bonds - defaults (sulfate in mixture of H20 and NH3)"
-  "goldentests/output/SulfateInSolution__GuessBonds6.txyz" $ do
-    raw <- T.readFile "goldentests/input/SulfateInSolution.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let molResult = guessBonds Nothing molInput
-        return . LBS.fromString . writeTXYZ $ molResult
-
--- Isolating ONIOM layers and capping dangling bonds
-testIsolateLayer1 :: TestTree
-testIsolateLayer1 = goldenVsString
-  "Isolate ONIOM layer - defaults (Heme like system, isolate Fe-porphyrine)"
-  "goldentests/output/FePorphyrine__IsolateLayer1.txyz" $ do
-    raw <- T.readFile "goldentests/input/FePorphyrine.txyz"
-    case (eitherResult $ parse parseTXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let molResult = isolateLayer [0 .. 35] Nothing Nothing molInput
-        return . LBS.fromString . writeTXYZ . fromMaybe moleculeEmpty $ molResult
-
-testIsolateLayer2 :: TestTree
-testIsolateLayer2 = goldenVsString
-  "Isolate ONIOM layer - fluorine capping, short dinstance (Ru complex with H20 solvent molecules)"
-  "goldentests/output/RuKomplex__IsolateLayer2.txyz" $ do
-    raw <- T.readFile "goldentests/input/RuKomplex.txyz"
-    case (eitherResult $ parse parseTXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let molResult = isolateLayer
-              (  [0 .. 19]                                                                -- bPy
-              ++ [20]                                                                     -- Ru
-              ++ [26, 22, 21, 25, 27, 28, 33, 23, 24, 30, 31, 32, 36, 37, 34, 35, 38, 39] -- bPy
-              ++ [46, 42, 44, 41, 43, 45, 49, 47, 48, 50, 51, 52, 54, 55, 57, 56, 58, 53] -- bPy
-              ++ [95, 98]                                                                 -- PO
-              ++ [126, 127, 128]                                                          -- H2O
-              ) (Just F) (Just 0.6) molInput
-        return . LBS.fromString . writeTXYZ . fromMaybe moleculeEmpty $ molResult
-
--- Fragment detection
-testFragmentDetection1 :: TestTree
-testFragmentDetection1 = goldenVsString
-  "Detect fragments - remove all bonds (sulfate in mixture of H20 and NH3)"
-  "goldentests/output/SulfateInSolution__FragmentDetection1.xyz" $ do
-    raw <- T.readFile "goldentests/input/SulfateInSolution.txyz"
-    case (eitherResult $ parse parseTXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let fragments =
-              LBS.fromString . concat . map writeTXYZ . snd <$>
-              fragmentMolecule RemoveAll molInput
-        case fragments of
-          Nothing -> return $ LBS.fromString "Failed"
-          Just s  -> return s
-
-testFragmentDetection2 :: TestTree
-testFragmentDetection2 = goldenVsString
-  "Detect fragments - new bond guess (sulfate in mixture of H20 and NH3)"
-  "goldentests/output/SulfateInSolution__FragmentDetection2.xyz" $ do
-    raw <- T.readFile "goldentests/input/SulfateInSolution.txyz"
-    case (eitherResult $ parse parseTXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let fragments =
-              LBS.fromString . concat . map writeTXYZ . snd <$>
-              fragmentMolecule (NewGuess (Just 1.4)) molInput
-        case fragments of
-          Nothing -> return $ LBS.fromString "Failed"
-          Just s  -> return s
-
-testFragmentDetection3 :: TestTree
-testFragmentDetection3 = goldenVsString
-  "Detect fragments - keeping supermol bonds (toluene Cl2 mixture periodic)"
-  "goldentests/output/TolueneCl2__FragmentDetection3.txyz" $ do
-    raw <- T.readFile "goldentests/input/TolueneCl2.txyz"
-    case (eitherResult $ parse parseTXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let fragments =
-              LBS.fromString . concat . map writeTXYZ . snd <$>
-              fragmentMolecule KeepBonds molInput
-        case fragments of
-          Nothing -> return $ LBS.fromString "Failed"
-          Just s  -> return s
-
--- Wrapping of fragments to unit cell molecule-wise
-testWrapFragmentsToBox1 :: TestTree
-testWrapFragmentsToBox1 = goldenVsString
-  "Wrap molecules to unit cell molecule-wise (toluene Cl2 mixture periodic)"
-  "goldentests/output/TolueneCl2__WrapFragmentsToBox1.txyz" $ do
-    raw <- T.readFile "goldentests/input/TolueneCl2.txyz"
-    case (eitherResult $ parse parseTXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let superMolFragmented =
-              LBS.fromString . writeTXYZ . fst . wrapFragmentsToBox (20.0, 20.0, 20.0) <$>
-              fragmentMolecule KeepBonds molInput
-        case superMolFragmented of
-          Nothing -> return $ LBS.fromString "Failed"
-          Just s  -> return s
-
--- | Supercell generation
-testReplicateSystemAlongAxis1 :: TestTree
-testReplicateSystemAlongAxis1 = goldenVsString
-  "Replicate unit cell - x axis (toluene Cl2 mixture periodic)"
-  "goldentests/output/TolueneCl2__ReplicateSystemAlongAxis1.xyz" $ do
-    raw <- T.readFile "goldentests/input/TolueneCl2.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let superCell = replicateSystemAlongAxis (20.0, 20.0, 20.0) AxisX molInput
-        return . LBS.fromString . writeXYZ $ superCell
-
-testReplicateSystemAlongAxis2 :: TestTree
-testReplicateSystemAlongAxis2 = goldenVsString
-  "Replicate unit cell - y axis (toluene Cl2 mixture periodic)"
-  "goldentests/output/TolueneCl2__ReplicateSystemAlongAxis2.xyz" $ do
-    raw <- T.readFile "goldentests/input/TolueneCl2.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let superCell = replicateSystemAlongAxis (20.0, 20.0, 20.0) AxisY molInput
-        return . LBS.fromString . writeXYZ $ superCell
-
-testReplicateSystemAlongAxis3 :: TestTree
-testReplicateSystemAlongAxis3 = goldenVsString
-  "Replicate unit cell - z axis (toluene Cl2 mixture periodic)"
-  "goldentests/output/TolueneCl2__ReplicateSystemAlongAxis3.xyz" $ do
-    raw <- T.readFile "goldentests/input/TolueneCl2.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let superCell = replicateSystemAlongAxis (20.0, 20.0, 20.0) AxisZ molInput
-        return . LBS.fromString . writeXYZ $ superCell
-
--- Nearest neighbour search
-testFindNearestAtom1 :: TestTree
-testFindNearestAtom1 = goldenVsString
-  "Find nearest atom (toluene Cl2 mixture periodic)"
-  "goldentests/output/N2_bonded__FindNearestAtom1.dat" $ do
-    raw <- T.readFile "goldentests/input/N2_bonded.xyz"
-    case (eitherResult $ parse parseXYZ raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right molInput -> do
-        let nearestInfo = findNearestAtom (0.0, 0.0, 0.5499) molInput
-        return . LBS.fromString . show $ nearestInfo
-
--- Test criterion filtering
-testFilterByCriteria1 :: TestTree
-testFilterByCriteria1 = goldenVsString
-  "Trajectory filtering - distance criterion (azine and phophinin)"
-  "goldentests/output/HeteroTraj__FilterByCriteria1.xyz" $ do
-    raw <- T.readFile "goldentests/input/HeteroTraj.xyz"
-    case (eitherResult $ parse (many1 parseXYZ) raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right trajInput -> do
-        let filteredTraj =
-              filterByCriteria
-              [ fromMaybe False <$> (criterionDistance (2, 16) (< 5.0))
-              ] trajInput
-        return . LBS.fromString . concat . map writeXYZ $ filteredTraj
-
-testFilterByCriteria2 :: TestTree
-testFilterByCriteria2 = goldenVsString
-  "Trajectory filtering - 4 atoms angle criterion (azine and phophinin)"
-  "goldentests/output/HeteroTraj__FilterByCriteria2.xyz" $ do
-    raw <- T.readFile "goldentests/input/HeteroTraj.xyz"
-    case (eitherResult $ parse (many1 parseXYZ) raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right trajInput -> do
-        let filteredTraj =
-              filterByCriteria
-              [ fromMaybe False <$> (criterionAngle4Atoms ((5, 2), (2, 16)) (< 1.5708))
-              ] trajInput
-        return . LBS.fromString . concat . map writeXYZ $ filteredTraj
-
-testFilterByCriteria3 :: TestTree
-testFilterByCriteria3 = goldenVsString
-  "Trajectory filtering - 2 distance criteria (azine and phophinin)"
-  "goldentests/output/HeteroTraj__FilterByCriteria3.xyz" $ do
-    raw <- T.readFile "goldentests/input/HeteroTraj.xyz"
-    case (eitherResult $ parse (many1 parseXYZ) raw) of
-      Left _ -> return $ LBS.fromString "Failed"
-      Right trajInput -> do
-        let filteredTraj =
-              filterByCriteria
-              [ fromMaybe False <$> (criterionDistance (2, 16) (< 3.85))
-              , fromMaybe False <$> (criterionDistance (14, 5) (> 7.85))
-              ] trajInput
-        return . LBS.fromString . concat . map writeXYZ $ filteredTraj
--}

--- a/package.yaml
+++ b/package.yaml
@@ -56,6 +56,7 @@ dependencies:
   - aeson-pretty >= 0.8.7
   - vector >= 0.12.0.0
   - transformers >= 0.5.6.2
+  - safe-exceptions >= 0.1.7.0
   # Accelerate
   - accelerate >= 1.3.0.0 && <= 1.4.0.0
   - accelerate-llvm >= 1.3.0.0 && <= 1.4.0.0

--- a/spicy.cabal
+++ b/spicy.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ce9efd07789c2822a02c3709f518367cc687758e201731eed397e487e2e3dd9c
+-- hash: 3ec6c73eb9c7d34aa1b5f6744d900e3aae8206911f44d51a5cf0ec300c64d100
 
 name:           spicy
 version:        0.0.0.1
@@ -102,6 +102,7 @@ library
     , lens-accelerate >=0.3.0.0 && <=0.4.0.0
     , microlens-platform >=0.3.9.0
     , parallel >=3.2.1.0
+    , safe-exceptions >=0.1.7.0
     , split >=0.2.3.2
     , text >=1.2.2.0
     , transformers >=0.5.6.2
@@ -146,6 +147,7 @@ executable benchmarks-exe
     , lens-accelerate >=0.3.0.0 && <=0.4.0.0
     , microlens-platform >=0.3.9.0
     , parallel >=3.2.1.0
+    , safe-exceptions >=0.1.7.0
     , spicy
     , split >=0.2.3.2
     , text >=1.2.2.0
@@ -190,6 +192,7 @@ executable spicy
     , lens-accelerate >=0.3.0.0 && <=0.4.0.0
     , microlens-platform >=0.3.9.0
     , parallel >=3.2.1.0
+    , safe-exceptions >=0.1.7.0
     , spicy
     , split >=0.2.3.2
     , text >=1.2.2.0
@@ -234,6 +237,7 @@ executable unittests-exe
     , lens-accelerate >=0.3.0.0 && <=0.4.0.0
     , microlens-platform >=0.3.9.0
     , parallel >=3.2.1.0
+    , safe-exceptions >=0.1.7.0
     , spicy
     , split >=0.2.3.2
     , tasty >=0.11.3
@@ -282,6 +286,7 @@ test-suite unittests
     , lens-accelerate >=0.3.0.0 && <=0.4.0.0
     , microlens-platform >=0.3.9.0
     , parallel >=3.2.1.0
+    , safe-exceptions >=0.1.7.0
     , spicy
     , split >=0.2.3.2
     , tasty >=0.11.3
@@ -331,6 +336,7 @@ benchmark benchmarks
     , lens-accelerate >=0.3.0.0 && <=0.4.0.0
     , microlens-platform >=0.3.9.0
     , parallel >=3.2.1.0
+    , safe-exceptions >=0.1.7.0
     , spicy
     , split >=0.2.3.2
     , text >=1.2.2.0

--- a/src/Spicy/Parser.hs
+++ b/src/Spicy/Parser.hs
@@ -20,6 +20,7 @@ module Spicy.Parser
 , parsePDB
 ) where
 import           Control.Applicative
+import           Control.Exception.Safe
 import           Data.Attoparsec.Text.Lazy
 import           Data.Char
 import           Data.Either
@@ -43,7 +44,6 @@ import           Prelude                   hiding (cycle, foldl1, foldr1, head,
 import           Spicy.Molecule.Util
 import           Spicy.Types
 import           Text.Read
-import Data.Typeable
 -- import Data.Monoid
 -- import Data.Sequence (Seq)
 -- import Debug.Trace
@@ -70,11 +70,11 @@ Convert strict text to lazy text.
 textS2L :: TS.Text -> TL.Text
 textS2L = TL.pack . TS.unpack
 
-parse' :: MonadThrow m, Typeable a => Parser a -> TL.Text -> m a
+parse' :: MonadThrow m => Parser a -> TL.Text -> m a
 parse' p t =
   case parse p t of
-    Done _ r -> return r
-    Fail _ _ e -> throwM $ ParserException ""
+    Done _ r   -> return r
+    Fail _ _ e -> throwM $ ParserException e
 ----------------------------------------------------------------------------------------------------
 {-|
 Parse a .xyz file (has no connectivity, atom types or partioal charges).

--- a/src/Spicy/Parser.hs
+++ b/src/Spicy/Parser.hs
@@ -13,8 +13,9 @@ provided, as this is a JSON structured file, which should be parsed by
 -}
 {-# LANGUAGE OverloadedStrings #-}
 module Spicy.Parser
-( -- * Chemical Data Formats
-  parseXYZ
+( parse'
+  -- * Chemical Data Formats
+, parseXYZ
 , parseTXYZ
 , parseMOL2
 , parsePDB

--- a/src/Spicy/Parser.hs
+++ b/src/Spicy/Parser.hs
@@ -43,6 +43,7 @@ import           Prelude                   hiding (cycle, foldl1, foldr1, head,
 import           Spicy.Molecule.Util
 import           Spicy.Types
 import           Text.Read
+import Data.Typeable
 -- import Data.Monoid
 -- import Data.Sequence (Seq)
 -- import Debug.Trace
@@ -69,6 +70,11 @@ Convert strict text to lazy text.
 textS2L :: TS.Text -> TL.Text
 textS2L = TL.pack . TS.unpack
 
+parse' :: MonadThrow m, Typeable a => Parser a -> TL.Text -> m a
+parse' p t =
+  case parse p t of
+    Done _ r -> return r
+    Fail _ _ e -> throwM $ ParserException ""
 ----------------------------------------------------------------------------------------------------
 {-|
 Parse a .xyz file (has no connectivity, atom types or partioal charges).

--- a/src/Spicy/Types.hs
+++ b/src/Spicy/Types.hs
@@ -17,6 +17,7 @@ takes care of the description of molecules (structure, topology, potential energ
 module Spicy.Types
 ( MolLogicException(..)
 , DataStructureException(..)
+, ParserException(..)
 , Strat(..)
 , AccVector(..)
 , AccMatrix(..)
@@ -71,7 +72,10 @@ class NiceShow a where
 Exception type for operations on 'Molecule's, which lead to a logical error. This can be caused
 because some Spicy assumptions are not met for example.
 -}
-data MolLogicException = MolLogicException String String deriving Typeable
+data MolLogicException = MolLogicException
+  { mlExcFunctionName :: String
+  , mlExcDescription  :: String
+  } deriving Typeable
 instance Show MolLogicException where
   show (MolLogicException f e) = "MoleculeLogicException in function \"" ++ f ++ "\":" ++ e
 instance Exception MolLogicException
@@ -80,10 +84,24 @@ instance Exception MolLogicException
 Exception type for operations on data structures, which are not meeting necessary criteria for the
 operation to perform.
 -}
-data DataStructureException = DataStructureException String String deriving Typeable
+data DataStructureException = DataStructureException
+  { dsExcFunctionName :: String
+  , dsExcDescription  :: String
+  } deriving Typeable
 instance Show DataStructureException where
   show (DataStructureException f e) = "DataStructureException in function \"" ++ f ++ "\":" ++ e
 instance Exception DataStructureException
+
+{-|
+Exception type for textual or binary data, that could not be parsed.
+-}
+data ParserException = ParserException
+  { pExcParser      :: String
+  , pExcType        :: String
+  } deriving Typeable
+instance Show ParserException where
+  show (ParserException p e) = "DataStructureException in parser \"" ++ f ++ "\":" ++ e
+instance Exception ParserException
 
 {-|
 Use serial or parallel processing for large data structures. This helps deciding on a per use base,

--- a/src/Spicy/Types.hs
+++ b/src/Spicy/Types.hs
@@ -51,7 +51,6 @@ import           Data.IntMap.Lazy          (IntMap)
 import           Data.IntSet               (IntSet)
 import           Data.Sequence             (Seq)
 import           Data.Text.Lazy            (Text)
-import           Data.Typeable
 import           GHC.Generics              (Generic)
 import           Lens.Micro.Platform       hiding ((.=))
 import           Prelude                   hiding (cycle, foldl1, foldr1, head,
@@ -75,7 +74,7 @@ because some Spicy assumptions are not met for example.
 data MolLogicException = MolLogicException
   { mlExcFunctionName :: String
   , mlExcDescription  :: String
-  } deriving Typeable
+  }
 instance Show MolLogicException where
   show (MolLogicException f e) = "MoleculeLogicException in function \"" ++ f ++ "\":" ++ e
 instance Exception MolLogicException
@@ -87,7 +86,7 @@ operation to perform.
 data DataStructureException = DataStructureException
   { dsExcFunctionName :: String
   , dsExcDescription  :: String
-  } deriving Typeable
+  }
 instance Show DataStructureException where
   show (DataStructureException f e) = "DataStructureException in function \"" ++ f ++ "\":" ++ e
 instance Exception DataStructureException

--- a/src/Spicy/Types.hs
+++ b/src/Spicy/Types.hs
@@ -15,7 +15,9 @@ takes care of the description of molecules (structure, topology, potential energ
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell   #-}
 module Spicy.Types
-( Strat(..)
+( MolLogicException(..)
+, DataStructureException(..)
+, Strat(..)
 , AccVector(..)
 , AccMatrix(..)
 , Element(..)
@@ -39,6 +41,7 @@ module Spicy.Types
 , Trajectory
 ) where
 import           Control.DeepSeq
+import           Control.Exception.Safe
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import qualified Data.Array.Accelerate     as A
@@ -47,6 +50,7 @@ import           Data.IntMap.Lazy          (IntMap)
 import           Data.IntSet               (IntSet)
 import           Data.Sequence             (Seq)
 import           Data.Text.Lazy            (Text)
+import           Data.Typeable
 import           GHC.Generics              (Generic)
 import           Lens.Micro.Platform       hiding ((.=))
 import           Prelude                   hiding (cycle, foldl1, foldr1, head,
@@ -62,6 +66,24 @@ class NiceShow a where
   niceShow    :: a -> String -- ^ Printing the isolated object
   niceComplex :: a -> String -- ^ Printing the object in the complex form, where everything is meant
                              --   to be printed at once as overview
+
+{-|
+Exception type for operations on 'Molecule's, which lead to a logical error. This can be caused
+because some Spicy assumptions are not met for example.
+-}
+data MolLogicException = MolLogicException String String deriving Typeable
+instance Show MolLogicException where
+  show (MolLogicException f e) = "MoleculeLogicException in function \"" ++ f ++ "\":" ++ e
+instance Exception MolLogicException
+
+{-|
+Exception type for operations on data structures, which are not meeting necessary criteria for the
+operation to perform.
+-}
+data DataStructureException = DataStructureException String String deriving Typeable
+instance Show DataStructureException where
+  show (DataStructureException f e) = "DataStructureException in function \"" ++ f ++ "\":" ++ e
+instance Exception DataStructureException
 
 {-|
 Use serial or parallel processing for large data structures. This helps deciding on a per use base,

--- a/src/Spicy/Types.hs
+++ b/src/Spicy/Types.hs
@@ -95,12 +95,9 @@ instance Exception DataStructureException
 {-|
 Exception type for textual or binary data, that could not be parsed.
 -}
-data ParserException = ParserException
-  { pExcParser      :: String
-  , pExcType        :: String
-  } deriving Typeable
+data ParserException = ParserException String
 instance Show ParserException where
-  show (ParserException p e) = "DataStructureException in parser \"" ++ f ++ "\":" ++ e
+  show (ParserException e) = "ParserException in parser: \"" ++ e ++ "\""
 instance Exception ParserException
 
 {-|


### PR DESCRIPTION
# General description of the changes
This branch improves the error types. By using [FPComplete's recommendations on error handling](https://tech.fpcomplete.com/blog/2016/11/exceptions-best-practices-haskell), composable error types with minimum amount of monad transformers are introduced.

# Checklist
  - [x] All top level functions and exports are doccumented with Haddock
  - [x] Compiles without warnings, when using `package.yaml` without the `dev` flag
  - [x] No partial functions have been used
  - [x] Unit tests / golden tests for all functions actually exported for modules not considered and marked "Internal" have been added and all tests pass
  - [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/sheepforce/Spicy/blob/master/CONTRIBUTING.md)

# Changes
  - Specific error types has been introduced in `Spicy.Types` (`MolLogicException`, `DataStructureException` and `ParserException`).
  - all functions, that were using `Either Text` types of errors are now using `MonadThrow` with proper error types.
  - The unit tests are not using monad transformers any more but report the dramatic parsing errors as IO errors, as they cannot be caught anyways.
  - Introduction of a function `Spicy.Parser.parse'`, which wraps attoparsec `parse` to the `MonadThrow` type. From now on `parse'` should always be used for parsing!
  - Old test cases, which were commented out from the unit test suite have been removed.
  - Adding an `apt clean` to `travis.yml` to fix the checksum errors on the Travis servers

# API breaks
 - [x] This commit breaks compatibility of old functions/types/...

 - In `Spicy.Math.vCross` is changed from `Either Text` to `MonadThrow`.
 - `Spicy.Parser.parse'` replaces all occurences of `parse` from attoparsec.
 - `Spicy.Writer.Molecule` has all writers changed in the error type from `Either Text` errors to `MonadThrow`, except `writeSpicy` of course, which cannot fail.
